### PR TITLE
[OpenMP] Support library runtime functions

### DIFF
--- a/LLVMFloatToFixed/CMakeLists.txt
+++ b/LLVMFloatToFixed/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_library(${SELF} OBJECT BUILDTREE_ONLY
   MDCollector.cpp
   Conversion.cpp
   ConstantConversion.cpp
+  IndirectCallConversion.cpp
   InstructionConversion.cpp
 
   ADDITIONAL_HEADERS

--- a/LLVMFloatToFixed/IndirectCallConversion.cpp
+++ b/LLVMFloatToFixed/IndirectCallConversion.cpp
@@ -1,5 +1,3 @@
-#include "LLVMFloatToFixedPass.h"
-#include "TypeUtils.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
@@ -9,6 +7,8 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
+#include "LLVMFloatToFixedPass.h"
+#include "TypeUtils.h"
 
 using namespace llvm;
 using namespace taffo;

--- a/LLVMFloatToFixed/IndirectCallConversion.cpp
+++ b/LLVMFloatToFixed/IndirectCallConversion.cpp
@@ -1,26 +1,31 @@
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/Constants.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/InstIterator.h"
-#include "llvm/IR/Intrinsics.h"
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/Support/raw_ostream.h"
-#include <llvm/Transforms/Utils/ValueMapper.h>
-#include <llvm/Transforms/Utils/Cloning.h>
 #include "LLVMFloatToFixedPass.h"
 #include "TypeUtils.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
+#include <llvm/Transforms/Utils/Cloning.h>
+#include <llvm/Transforms/Utils/ValueMapper.h>
 
 using namespace llvm;
 using namespace taffo;
 using namespace flttofix;
 
-void FloatToFixed::convertIndirectCalls(llvm::Module& m) {
+/// Retrieve the indirect calls converted into trampolines and re-use the
+/// original indirect functions.
+void FloatToFixed::convertIndirectCalls(llvm::Module &m) {
   std::vector<llvm::CallInst *> trampolineCalls;
 
+  // Retrieve the trampoline calls using the INDIRECT_METADATA
   for (llvm::Function &curFunction : m) {
-    for (auto instructionIt = inst_begin(curFunction); instructionIt != inst_end(curFunction); instructionIt++) {
-      if (auto curCallInstruction = llvm::dyn_cast<llvm::CallInst>(&(*instructionIt))) {
+    for (auto instructionIt = inst_begin(curFunction);
+         instructionIt != inst_end(curFunction); instructionIt++) {
+      if (auto curCallInstruction =
+              llvm::dyn_cast<llvm::CallInst>(&(*instructionIt))) {
         if (curCallInstruction->getMetadata(INDIRECT_METADATA)) {
           trampolineCalls.push_back(curCallInstruction);
         }
@@ -28,60 +33,46 @@ void FloatToFixed::convertIndirectCalls(llvm::Module& m) {
     }
   }
 
-  for (auto trampolineCall: trampolineCalls) {
-    auto *metadata = dyn_cast<ValueAsMetadata>(*trampolineCall->getMetadata(INDIRECT_METADATA)->op_begin());
-    Function *indirectFunction = dyn_cast<Function>(metadata->getValue());
+  // Convert the trampoline calls
+  for (auto trampolineCall : trampolineCalls) {
+    auto *metadata = dyn_cast<ValueAsMetadata>(
+        *trampolineCall->getMetadata(INDIRECT_METADATA)->op_begin());
+    auto *indirectFunction = dyn_cast<Function>(metadata->getValue());
 
-    // FIXME Use a map instead of if, figuring out the type of FloatToFixed::handleKmpcFork
     if (indirectFunction->getName() == "__kmpc_fork_call") {
       handleKmpcFork(trampolineCall, indirectFunction);
     }
-    else if (indirectFunction->getName() == "__kmpc_reduce_nowait") {
-      handleReduce(trampolineCall, indirectFunction);
-    }
-
   }
 }
 
-void FloatToFixed::handleKmpcFork(CallInst *I, Function *indirectFunction) {
-  auto calledFunction = cast<CallInst>(I)->getCalledFunction();
+/// Convert a trampoline call to the kmpc_fork back into the library function
+void FloatToFixed::handleKmpcFork(CallInst *patchedDirectCall,
+                                  Function *indirectFunction) {
+  auto calledFunction = cast<CallInst>(patchedDirectCall)->getCalledFunction();
   auto entryBlock = &calledFunction->getEntryBlock();
 
+  // Get the fixp call instruction to use it as an argument for the library
+  // indirect function
   auto fixpCallInstr = entryBlock->getTerminator()->getPrevNode();
-  assert(llvm::isa<llvm::CallInst>(fixpCallInstr) && "expected a CallInst to the outlined function");
+  assert(llvm::isa<llvm::CallInst>(fixpCallInstr) &&
+         "expected a CallInst to the outlined function");
   auto fixpCall = cast<CallInst>(fixpCallInstr);
 
+  // Use bitcast to keep compatibility with the OpenMP runtime reference
   auto microTaskType = indirectFunction->getArg(2)->getType();
-  auto bitcastedMicroTask = ConstantExpr::getBitCast(fixpCall->getCalledFunction(), microTaskType);
+  auto bitcastedMicroTask =
+      ConstantExpr::getBitCast(fixpCall->getCalledFunction(), microTaskType);
 
-  std::vector<Value *> indirectCallArgs = std::vector<Value *>(I->arg_begin(), I->arg_end());
+  // Add the indirect arguments
+  std::vector<Value *> indirectCallArgs = std::vector<Value *>(
+      patchedDirectCall->arg_begin(), patchedDirectCall->arg_end());
   indirectCallArgs.insert(indirectCallArgs.begin() + 2, bitcastedMicroTask);
 
+  // Insert the indirect call after the patched direct call
   auto indirectCall = CallInst::Create(indirectFunction, indirectCallArgs);
-  indirectCall->insertAfter(I);
+  indirectCall->insertAfter(patchedDirectCall);
+  cpMetaData(indirectCall, patchedDirectCall);
 
-  cpMetaData(indirectCall, I);
-
-  I->eraseFromParent();
-}
-
-void FloatToFixed::handleReduce(CallInst *I, Function *indirectFunction) {
-  auto calledFunction = cast<CallInst>(I)->getCalledFunction();
-  auto entryBlock = &calledFunction->getEntryBlock();
-
-  auto fixpCallInstr = entryBlock->getTerminator()->getPrevNode();
-  assert(llvm::isa<llvm::CallInst>(fixpCallInstr) && "expected a CallInst to the outlined function");
-  auto fixpCall = cast<CallInst>(fixpCallInstr);
-  
-  std::vector<Value *> indirectCallArgs = std::vector<Value *>(I->arg_begin(), I->arg_end());
-  indirectCallArgs[5] = fixpCall->getCalledFunction();
-
-  auto indirectCall = CallInst::Create(indirectFunction, indirectCallArgs);
-  indirectCall->insertAfter(I);
-
-  cpMetaData(indirectCall, I);
-
-  I->replaceAllUsesWith(indirectCall);
-
-  I->eraseFromParent();
+  // Remove the patched direct call
+  patchedDirectCall->eraseFromParent();
 }

--- a/LLVMFloatToFixed/IndirectCallConversion.cpp
+++ b/LLVMFloatToFixed/IndirectCallConversion.cpp
@@ -23,7 +23,8 @@ const std::map<const std::string, handler_function> indirectCallFunctions = {
 
 /// Retrieve the indirect calls converted into trampolines and re-use the
 /// original indirect functions.
-void FloatToFixed::convertIndirectCalls(llvm::Module &m) {
+void FloatToFixed::convertIndirectCalls(llvm::Module &m)
+{
   std::vector<llvm::CallInst *> trampolineCalls;
 
   // Retrieve the trampoline calls using the INDIRECT_METADATA
@@ -65,7 +66,8 @@ void FloatToFixed::convertIndirectCalls(llvm::Module &m) {
 /// Convert a trampoline call to an outlined function back into the original
 /// library function
 void FloatToFixed::handleKmpcFork(CallInst *patchedDirectCall,
-                                  Function *indirectFunction) {
+                                  Function *indirectFunction)
+{
   auto calledFunction = cast<CallInst>(patchedDirectCall)->getCalledFunction();
   auto entryBlock = &calledFunction->getEntryBlock();
 

--- a/LLVMFloatToFixed/IndirectCallConversion.cpp
+++ b/LLVMFloatToFixed/IndirectCallConversion.cpp
@@ -1,0 +1,62 @@
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Support/raw_ostream.h"
+#include <llvm/Transforms/Utils/ValueMapper.h>
+#include <llvm/Transforms/Utils/Cloning.h>
+#include "LLVMFloatToFixedPass.h"
+#include "TypeUtils.h"
+
+using namespace llvm;
+using namespace taffo;
+using namespace flttofix;
+
+void FloatToFixed::convertIndirectCalls(llvm::Module& m) {
+  std::vector<llvm::CallInst *> trampolineCalls;
+
+  for (llvm::Function &curFunction : m) {
+    for (auto instructionIt = inst_begin(curFunction); instructionIt != inst_end(curFunction); instructionIt++) {
+      if (auto curCallInstruction = llvm::dyn_cast<llvm::CallInst>(&(*instructionIt))) {
+        if (curCallInstruction->getMetadata(INDIRECT_METADATA)) {
+          trampolineCalls.push_back(curCallInstruction);
+        }
+      }
+    }
+  }
+
+  for (auto trampolineCall: trampolineCalls) {
+    auto *metadata = dyn_cast<ValueAsMetadata>(*trampolineCall->getMetadata(INDIRECT_METADATA)->op_begin());
+    Function *indirectFunction = dyn_cast<Function>(metadata->getValue());
+
+    // FIXME Use a map instead of if, figuring out the type of FloatToFixed::handleKmpcFork
+    if (indirectFunction->getName() == "__kmpc_fork_call") {
+      handleKmpcFork(trampolineCall, indirectFunction);
+    }
+  }
+}
+
+void FloatToFixed::handleKmpcFork(CallInst *I, Function *indirectFunction) {
+  auto calledFunction = cast<CallInst>(I)->getCalledFunction();
+  auto entryBlock = &calledFunction->getEntryBlock();
+
+  auto fixpCallInstr = entryBlock->getTerminator()->getPrevNode();
+  assert(llvm::isa<llvm::CallInst>(fixpCallInstr) && "expected a CallInst to the outlined function");
+  auto fixpCall = cast<CallInst>(fixpCallInstr);
+
+  auto microTaskType = indirectFunction->getArg(2)->getType();
+  auto bitcastedMicroTask = ConstantExpr::getBitCast(fixpCall->getCalledFunction(), microTaskType);
+
+  std::vector<Value *> indirectCallArgs = std::vector<Value *>(I->arg_begin(), I->arg_end());
+  indirectCallArgs.insert(indirectCallArgs.begin() + 2, bitcastedMicroTask);
+
+  auto indirectCall = CallInst::Create(indirectFunction, indirectCallArgs);
+  indirectCall->insertAfter(I);
+
+  cpMetaData(indirectCall, I);
+
+  I->eraseFromParent();
+}

--- a/LLVMFloatToFixed/IndirectCallConversion.cpp
+++ b/LLVMFloatToFixed/IndirectCallConversion.cpp
@@ -14,17 +14,15 @@ using namespace llvm;
 using namespace taffo;
 using namespace flttofix;
 
-using handler_function = void (FloatToFixed::*)(
-    llvm::CallInst *patchedDirectCall, llvm::Function *indirectFunction);
-
-/// Map to keep track of the handled indirect functions for the conversion.
-const std::map<const std::string, handler_function> indirectCallFunctions = {
-    {"__kmpc_fork_call", &FloatToFixed::handleKmpcFork}};
-
 /// Retrieve the indirect calls converted into trampolines and re-use the
 /// original indirect functions.
 void FloatToFixed::convertIndirectCalls(llvm::Module &m)
 {
+  using handler_function = void (FloatToFixed::*)(
+          llvm::CallInst *patchedDirectCall, llvm::Function *indirectFunction);
+  const std::map<const std::string, handler_function> indirectCallFunctions = {
+          {"__kmpc_fork_call", &FloatToFixed::handleKmpcFork}};
+
   std::vector<llvm::CallInst *> trampolineCalls;
 
   // Retrieve the trampoline calls using the INDIRECT_METADATA

--- a/LLVMFloatToFixed/IndirectCallConversion.cpp
+++ b/LLVMFloatToFixed/IndirectCallConversion.cpp
@@ -45,14 +45,14 @@ void FloatToFixed::convertIndirectCalls(llvm::Module &m) {
   }
 }
 
-/// Convert a trampoline call to the kmpc_fork back into the library function
+/// Convert a trampoline call to an outlined function back into the original library function
 void FloatToFixed::handleKmpcFork(CallInst *patchedDirectCall,
                                   Function *indirectFunction) {
   auto calledFunction = cast<CallInst>(patchedDirectCall)->getCalledFunction();
   auto entryBlock = &calledFunction->getEntryBlock();
 
-  // Get the fixp call instruction to use it as an argument for the library
-  // indirect function
+  // Get the fixp call instruction to use it as an argument for the restored
+  // library function
   auto fixpCallInstr = entryBlock->getTerminator()->getPrevNode();
   assert(llvm::isa<llvm::CallInst>(fixpCallInstr) &&
          "expected a CallInst to the outlined function");

--- a/LLVMFloatToFixed/IndirectCallConversion.cpp
+++ b/LLVMFloatToFixed/IndirectCallConversion.cpp
@@ -81,5 +81,7 @@ void FloatToFixed::handleReduce(CallInst *I, Function *indirectFunction) {
 
   cpMetaData(indirectCall, I);
 
+  I->replaceAllUsesWith(indirectCall);
+
   I->eraseFromParent();
 }

--- a/LLVMFloatToFixed/LLVMFloatToFixedPass.h
+++ b/LLVMFloatToFixed/LLVMFloatToFixedPass.h
@@ -441,7 +441,7 @@ struct FloatToFixed : public llvm::ModulePass {
       md = from->getMetadata(INPUT_INFO_METADATA);
       targetMD = from->getMetadata(TARGET_METADATA);
       constInfoMD = from->getMetadata(CONST_INFO_METADATA);
-      openMPIndirectMD = from->getMetadata(OPENMP_INDIRECT_METADATA);
+      openMPIndirectMD = from->getMetadata(INDIRECT_METADATA);
     } else if (GlobalObject *from = dyn_cast<GlobalObject>(src)) {
       md = from->getMetadata(INPUT_INFO_METADATA);
       targetMD = from->getMetadata(TARGET_METADATA);
@@ -483,7 +483,7 @@ struct FloatToFixed : public llvm::ModulePass {
 
     if (openMPIndirectMD) {
       if (auto *to = dyn_cast<Instruction>(dst)) {
-        to->setMetadata(OPENMP_INDIRECT_METADATA, openMPIndirectMD);
+        to->setMetadata(INDIRECT_METADATA, openMPIndirectMD);
       }
     }
 
@@ -531,6 +531,10 @@ struct FloatToFixed : public llvm::ModulePass {
   }
 
   int getLoopNestingLevelOfValue(llvm::Value *v);
+
+  void convertIndirectCalls(llvm::Module &m);
+
+  void handleKmpcFork(llvm::CallInst *I, llvm::Function *indirectFunction);
 };
 
 

--- a/LLVMFloatToFixed/LLVMFloatToFixedPass.h
+++ b/LLVMFloatToFixed/LLVMFloatToFixedPass.h
@@ -535,6 +535,7 @@ struct FloatToFixed : public llvm::ModulePass {
   void convertIndirectCalls(llvm::Module &m);
 
   void handleKmpcFork(llvm::CallInst *I, llvm::Function *indirectFunction);
+  void handleReduce(llvm::CallInst *I, llvm::Function *indirectFunction);
 };
 
 

--- a/LLVMFloatToFixed/LLVMFloatToFixedPass.h
+++ b/LLVMFloatToFixed/LLVMFloatToFixedPass.h
@@ -535,7 +535,6 @@ struct FloatToFixed : public llvm::ModulePass {
   void convertIndirectCalls(llvm::Module &m);
 
   void handleKmpcFork(llvm::CallInst *patchedDirectCall, llvm::Function *indirectFunction);
-  void handleReduce(llvm::CallInst *I, llvm::Function *indirectFunction);
 };
 
 

--- a/LLVMFloatToFixed/LLVMFloatToFixedPass.h
+++ b/LLVMFloatToFixed/LLVMFloatToFixedPass.h
@@ -434,10 +434,13 @@ struct FloatToFixed : public llvm::ModulePass {
     MDNode *md = nullptr;
     MDNode *targetMD = nullptr;
     MDNode *constInfoMD = nullptr;
+    MDNode *openMPIndirectMD = nullptr;
+
     if (Instruction *from = dyn_cast<Instruction>(src)) {
       md = from->getMetadata(INPUT_INFO_METADATA);
       targetMD = from->getMetadata(TARGET_METADATA);
       constInfoMD = from->getMetadata(CONST_INFO_METADATA);
+      openMPIndirectMD = from->getMetadata(OPENMP_INDIRECT_METADATA);
     } else if (GlobalObject *from = dyn_cast<GlobalObject>(src)) {
       md = from->getMetadata(INPUT_INFO_METADATA);
       targetMD = from->getMetadata(TARGET_METADATA);
@@ -474,6 +477,12 @@ struct FloatToFixed : public llvm::ModulePass {
 	Instruction *from = cast<Instruction>(src);
 	if (to->getNumOperands() == from->getNumOperands())
 	  to->setMetadata(CONST_INFO_METADATA, constInfoMD);
+      }
+    }
+
+    if (openMPIndirectMD) {
+      if (auto *to = dyn_cast<Instruction>(dst)) {
+        to->setMetadata(OPENMP_INDIRECT_METADATA, openMPIndirectMD);
       }
     }
 

--- a/LLVMFloatToFixed/LLVMFloatToFixedPass.h
+++ b/LLVMFloatToFixed/LLVMFloatToFixedPass.h
@@ -534,7 +534,7 @@ struct FloatToFixed : public llvm::ModulePass {
 
   void convertIndirectCalls(llvm::Module &m);
 
-  void handleKmpcFork(llvm::CallInst *I, llvm::Function *indirectFunction);
+  void handleKmpcFork(llvm::CallInst *patchedDirectCall, llvm::Function *indirectFunction);
   void handleReduce(llvm::CallInst *I, llvm::Function *indirectFunction);
 };
 

--- a/LLVMFloatToFixed/LLVMFloatToFixedPass.h
+++ b/LLVMFloatToFixed/LLVMFloatToFixedPass.h
@@ -103,6 +103,7 @@ struct FloatToFixed : public llvm::ModulePass {
   void closePhiLoops();
   void sortQueue(std::vector<llvm::Value*> &vals);
   void cleanup(const std::vector<llvm::Value*>& queue);
+  void insertOpenMPIndirection(llvm::Module& m);
   void propagateCall(std::vector<llvm::Value *> &vals, llvm::SmallPtrSetImpl<llvm::Value *> &global);
   llvm::Function *createFixFun(llvm::CallSite* call, bool *old);
   void printConversionQueue(std::vector<llvm::Value*> vals);


### PR DESCRIPTION
# TAFFO x OpenMP

This PR is one of four PRs concerning the integration of TAFFO with OpenMP:
1. Initializer PR, patching the runtime OpenMP library functions with a trampoline call (https://github.com/HEAPLab/TAFFO-submodule-init/pull/4)
2. Conversion PR, re-creating the correct runtime OpenMP library functions from the trampoline calls, after the conversion in fixed points
3. Test PR, with tests and the integration of the [PolyBench-ACC benchmark](https://github.com/cavazos-lab/PolyBench-ACC) (https://github.com/HEAPLab/TAFFO-test/pull/2)
4. TAFFO high-level PR, with the technical documentation (https://github.com/HEAPLab/TAFFO/pull/4)

## Summary
This PR adds an IndirectCallConversion source file, mirror of the Initializer's IndirectCallPatcher. It converts the indirect functions to fixed point, where necessary, and restores the supported OpenMP library functions, re-adding the indirection layer.